### PR TITLE
Add initial support for AzureDevOps repositories.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,6 +30,7 @@ pub enum Error {
     },
     GitLabDiffNotSupported,
     BitbucketDiffNotSupported,
+    AzureDevOpsNotSupported,
     NoUserInPath {
         path: String,
     },
@@ -115,6 +116,7 @@ impl fmt::Display for Error {
             Error::OpenUrlFailure {url, msg} => write!(f, "{}: Cannot open URL {}", msg, url),
             Error::GitLabDiffNotSupported => write!(f, "GitLab does not support '..' for comparing diff between commits. Please use '...'"),
             Error::BitbucketDiffNotSupported => write!(f, "BitBucket does not support diff between commits (see https://bitbucket.org/site/master/issues/4779/ability-to-diff-between-any-two-commits)"),
+            Error::AzureDevOpsNotSupported => write!(f, "Azure Devops does not currently support this operation"),
             Error::NoUserInPath{path} => write!(f, "Can't detect user name from path {}", path),
             Error::NoRepoInPath{path} => write!(f, "Can't detect repository name from path {}", path),
             Error::UnknownHostingService {url} => write!(f, "Unknown hosting service for URL {}. If you want to use custom URL for GitHub Enterprise, please set $GIT_BRWS_GHE_URL_HOST", url),

--- a/src/service.rs
+++ b/src/service.rs
@@ -263,36 +263,40 @@ fn build_bitbucket_url(user: &str, repo: &str, cfg: &Config, page: &Page) -> Res
     }
 }
 
-fn build_azdevops_url(
-    team: &str,
-    repo: &str,
-    cfg: &Config,
-    page: &Page,
-) -> Result<String> {
+fn build_azdevops_url(team: &str, repo: &str, cfg: &Config, page: &Page) -> Result<String> {
     match page {
-        Page::Open { pull_request: true, ..  } => {
+        Page::Open {
+            pull_request: true, ..
+        } => {
             if let Some(ref b) = cfg.branch {
                 Ok(format!("https://dev.azure.com/{}/_git/{}/pullrequestcreate?sourceRef={}&targetRef=master", team, repo, b))
             } else {
-                Err(Error::NoLocalRepoFound { operation: "opening a pull request without specifying branch".to_string(), })
+                Err(Error::NoLocalRepoFound {
+                    operation: "opening a pull request without specifying branch".to_string(),
+                })
             }
-        },
+        }
 
         Page::Open { .. } => {
             if let Some(ref b) = cfg.branch {
-                Ok(format!("https://dev.azure.com/{}/_git/{}?version=GB{}", team, repo, b))
+                Ok(format!(
+                    "https://dev.azure.com/{}/_git/{}?version=GB{}",
+                    team, repo, b
+                ))
             } else {
                 Ok(format!("https://dev.azure.com/{}/{}", team, repo))
             }
-        },
+        }
 
-        Page::Commit { ref hash } => {
-            Ok(format!("https://dev.azure.com/{}/_git/{}/commit/{}", team, repo, hash))
-        },
+        Page::Commit { ref hash } => Ok(format!(
+            "https://dev.azure.com/{}/_git/{}/commit/{}",
+            team, repo, hash
+        )),
 
-        Page::Tag { ref tagname, .. } => {
-            Ok(format!("https://dev.azure.com/{}/_git/{}?version=GT{}", team, repo, tagname))
-        },
+        Page::Tag { ref tagname, .. } => Ok(format!(
+            "https://dev.azure.com/{}/_git/{}?version=GT{}",
+            team, repo, tagname
+        )),
 
         Page::FileOrDir {
             ref relative_path,
@@ -308,11 +312,12 @@ fn build_azdevops_url(
             if *blame { "?_a=annotate" } else { "" },
         )),
 
-        Page::Issue { number } => {
-            Ok(format!("https://dev.azure.com/{}/{}/_workitems/edit/{}", team, repo, number))
-        },
+        Page::Issue { number } => Ok(format!(
+            "https://dev.azure.com/{}/{}/_workitems/edit/{}",
+            team, repo, number
+        )),
 
-       _ => Err(Error::AzureDevOpsNotSupported)
+        _ => Err(Error::AzureDevOpsNotSupported),
     }
 }
 
@@ -326,7 +331,8 @@ pub fn slug_from_path<'a>(path: &'a str) -> Result<(&'a str, &'a str)> {
     if user == "v3-special-az-devops-case" {
         // Skip v3 in azure devops ssh urls.
         user = split.next().ok_or_else(|| Error::NoUserInPath {
-        path: path.to_string(),})?;
+            path: path.to_string(),
+        })?;
     }
 
     let mut repo = split.next().ok_or_else(|| Error::NoRepoInPath {
@@ -338,7 +344,7 @@ pub fn slug_from_path<'a>(path: &'a str) -> Result<(&'a str, &'a str)> {
     } else if repo.ends_with("_git") {
         // Handle special case for weird azure urls.
         repo = split.next().ok_or_else(|| Error::NoRepoInPath {
-        path: path.to_string(),
+            path: path.to_string(),
         })?;
     }
     Ok((user, repo))

--- a/src/service.rs
+++ b/src/service.rs
@@ -345,17 +345,15 @@ pub fn slug_from_path<'a>(path: &'a str) -> Result<(&'a str, &'a str)> {
 }
 
 fn preprocess_repo_to_url(repo: &str) -> Result<Url> {
-    let processed_repo: String;
-
     // Workaround Url::parse not being able to parse the SSH urls for AzureDevOps,
     // it seems like the URL's don't adhere to the RFC?
-    if repo.contains("visualstudio.com:v3") || repo.contains("azure.com:v3") {
+    let processed_repo = if repo.contains("visualstudio.com:v3") || repo.contains("azure.com:v3") {
         // Hack: It should be nice to find a cleaner solution than having
         // this special marker that slug_from_path knows about.
-        processed_repo = repo.replace(":v3/", ":22/v3-special-az-devops-case/");
+        repo.replace(":v3/", ":22/v3-special-az-devops-case/")
     } else {
-        processed_repo = repo.to_string();
-    }
+        repo.to_string()
+    };
 
     Url::parse(&processed_repo).map_err(|e| Error::BrokenUrl {
         url: processed_repo,

--- a/src/service.rs
+++ b/src/service.rs
@@ -376,7 +376,7 @@ pub fn slug_from_path<'a>(path: &'a str) -> Result<(&'a str, &'a str)> {
     if repo.ends_with(".git") {
         // Slice '.git' from 'repo.git'
         repo = &repo[0..repo.len() - 4];
-    } 
+    }
 
     Ok((user, repo))
 }

--- a/src/test/service.rs
+++ b/src/test/service.rs
@@ -72,6 +72,14 @@ fn convert_ssh_url() {
             "ssh://git@bitbucket.org:22/user/repo.git",
             "https://bitbucket.org/user/repo",
         ),
+        (
+           "ssh://team@vs-ssh.visualstudio.com:v3/team/repo/repo",
+            "https://dev.azure.com/team/repo",
+        ),
+        (
+            "ssh://git@ssh.dev.azure.com:v3/team/repo/repo",
+            "https://dev.azure.com/team/repo",
+        ),
     ] {
         let c = config(repo, None, None);
         assert_eq!(build_page_url(&OPEN, &c).unwrap(), expected);
@@ -96,6 +104,10 @@ fn open_page_url() {
         (
             "https://gitlab.com/user/repo.git",
             "https://gitlab.com/user/repo",
+        ),
+        (
+            "https://dev.azure.com/team/repo/_git/repo",
+            "https://dev.azure.com/team/repo"
         ),
     ] {
         let c = config(repo, None, None);
@@ -126,6 +138,10 @@ fn open_branch_page_url() {
             "https://gitlab.somewhere.com/user/repo.git",
             "https://gitlab.somewhere.com/user/repo/tree/dev",
         ),
+        (
+            "https://dev.azure.com/team/_git/repo",
+            "https://dev.azure.com/team/_git/repo?version=GBdev",
+        ),
     ] {
         let c = config(repo, Some("dev"), None);
         assert_eq!(build_page_url(&OPEN, &c).unwrap(), expected);
@@ -153,6 +169,10 @@ fn commit_page_url() {
         (
             "https://gitlab.com/user/repo.git",
             "https://gitlab.com/user/repo/commit/90601f1037142605a32426f9ece0c07d479b9cc5",
+        ),
+        (
+            "https://dev.azure.com/team/_git/repo",
+            "https://dev.azure.com/team/_git/repo/commit/90601f1037142605a32426f9ece0c07d479b9cc5",
         ),
     ] {
         let c = config(repo, None, None);
@@ -224,6 +244,20 @@ fn diff_page_for_bitbucket_url() {
     assert!(
         build_page_url(&p, &c).is_err(),
         "bitbucket does not support diff page"
+    );
+}
+
+#[test]
+fn diff_page_for_azuredevops_url() {
+    let p = Page::Diff {
+        lhs: "561848bad7164d7568658456088b107ec9efd9f3".to_string(),
+        rhs: "90601f1037142605a32426f9ece0c07d479b9cc5".to_string(),
+        op: DiffOp::ThreeDots,
+    };
+    let c = config("https://dev.azure.com/team/repo/_git/repo", None, None);
+    assert!(
+        build_page_url(&p, &c).is_err(),
+        "azure devops does not support diff page"
     );
 }
 
@@ -408,6 +442,10 @@ fn issue_number_url() {
         (
             "https://gitlab.com/user/repo.git",
             "https://gitlab.com/user/repo/issues/123",
+        ),
+        (
+            "https://dev.azure.com/team/repo/_git/repo",
+            "https://dev.azure.com/team/repo/_workitems/edit/123"
         ),
     ] {
         let c = config(repo, None, None);

--- a/src/test/service.rs
+++ b/src/test/service.rs
@@ -73,7 +73,7 @@ fn convert_ssh_url() {
             "https://bitbucket.org/user/repo",
         ),
         (
-           "ssh://team@vs-ssh.visualstudio.com:v3/team/repo/repo",
+            "ssh://team@vs-ssh.visualstudio.com:v3/team/repo/repo",
             "https://dev.azure.com/team/repo",
         ),
         (
@@ -107,7 +107,7 @@ fn open_page_url() {
         ),
         (
             "https://dev.azure.com/team/repo/_git/repo",
-            "https://dev.azure.com/team/repo"
+            "https://dev.azure.com/team/repo",
         ),
     ] {
         let c = config(repo, None, None);
@@ -445,7 +445,7 @@ fn issue_number_url() {
         ),
         (
             "https://dev.azure.com/team/repo/_git/repo",
-            "https://dev.azure.com/team/repo/_workitems/edit/123"
+            "https://dev.azure.com/team/repo/_workitems/edit/123",
         ),
     ] {
         let c = config(repo, None, None);


### PR DESCRIPTION
This change implements basic support for repositories
hosted on AzureDevOps (formerly, Visual Studio Team Services).

Because there are many people who still use the old legacy URLs,
which continue to be supported, I've implemented support for both.

This ends up being a matrix of:
- http://visualstudio.com
- http://dev.azure.com
- ssh://vs-ssh.visualstudio.com
- ssh://ssh.dev.azure.com

I've included tests to validate all of the newly introduced functionality.