### PR TITLE
Add Arch Linux install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,16 @@ $ brew install git-brws
 It installs `git-brws` to `/usr/local/bin` and `git-brws.1` to `/usr/local/share/man/man1`.
 This is recommended way for installation on macOS since updating to the new version is easy.
 
+### On [Arch Linux](https://www.archlinux.org/)
+
+You can install `git-brws` via the [AUR package](https://aur.archlinux.org/packages/git-brws/):
+
+```
+git clone https://aur.archlinux.org/git-brws.git
+cd git-brws
+makepkg -si
+```
+
 ### With [cargo](https://crates.io/)
 
 ```


### PR DESCRIPTION
I created an [AUR package for git-brws](https://aur.archlinux.org/packages/git-brws/). This PR notes it in the README.